### PR TITLE
fix: update time miscalculation

### DIFF
--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -141,7 +141,7 @@ async function processIssues(client, args) {
       const rrTime = new Date(
         lastUpdateTme + MS_PER_DAY * args.daysBeforeStale
       );
-      if (lastUpdateTme > rrLabelTime) {
+      if (lastCommentTime > rrLabelTime) {
         log.debug(`issue was commented on after the label was applied`);
         if (args.dryrun) {
           log.info(

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -133,13 +133,14 @@ async function processIssues(client, args) {
         }
       }
     } else if (isLabeled(issue, responseRequestedLabel)) {
-      const lastUpdateTme = Date.parse(issue.updated_at);
+      const lastCommentTime = getLastCommentTime(issueTimelineEvents);
+      // const lastUpdateTme = Date.parse(issue.updated_at);
       const rrLabelTime = getLastLabelTime(
         issueTimelineEvents,
         responseRequestedLabel
       );
       const rrTime = new Date(
-        lastUpdateTme + MS_PER_DAY * args.daysBeforeStale
+        lastCommentTime + MS_PER_DAY * args.daysBeforeStale
       );
       if (lastCommentTime > rrLabelTime) {
         log.debug(`issue was commented on after the label was applied`);


### PR DESCRIPTION
*Description of changes:*
Turns out, we were checking for updated_at on response-requested, and not lastCommentTime. This swaps it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
