### PR TITLE
fix: check for responseRequested label before removing

### DIFF
--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -114,7 +114,9 @@ async function processIssues(client, args) {
           );
         } else {
           await removeLabel(client, issue, staleLabel);
-          await removeLabel(client, issue, responseRequestedLabel);
+          if (isLabeled(issue, responseRequestedLabel)) {
+            await removeLabel(client, issue, responseRequestedLabel);
+          }
         }
       } else {
         if (currentTime > sTime) {


### PR DESCRIPTION
*Description of changes:*
Adds one more isLabeled call when removing the stale label

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
