### PR TITLE
Added environment variable/argument use-created-date-for-ancient which if set to true uses issue created date instead of modified date for determining an ancient issue.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,8 @@ inputs:
     description: 'Set to DEBUG to enable debug logging'
   dry-run:
     description: 'Set to true to not perform repository changes'
+  use-created-date-for-ancient:
+    description: 'Set to true to use issue created date instead of modified date for determining an ancient issue.'
 
 runs:
   using: 'docker'
@@ -70,3 +72,4 @@ runs:
     MINIMUM_UPVOTES_TO_EXEMPT: ${{ inputs.minimum-upvotes-to-exempt }}
     LOGLEVEL: ${{ inputs.loglevel }}
     DRYRUN: ${{ inputs.dry-run }}
+    USE_CREATED_DATE_FOR_ANCIENT: ${{ inputs.use-created-date-for-ancient }}

--- a/src/entrypoint.js
+++ b/src/entrypoint.js
@@ -44,6 +44,7 @@ function getAndValidateInputs() {
     responseRequestedLabel: process.env.RESPONSE_REQUESTED_LABEL,
     minimumUpvotesToExempt: parseInt(process.env.MINIMUM_UPVOTES_TO_EXEMPT),
     dryrun: String(process.env.DRYRUN).toLowerCase() === 'true',
+    useCreatedDateForAncient: String(process.env.USE_CREATED_DATE_FOR_ANCIENT).toLowerCase() === 'true'
   };
 
   for (const numberInput of [
@@ -204,37 +205,48 @@ async function processIssues(client, args) {
           );
         }
       }
-    } else if (
-      Date.parse(issue.updated_at) <
-      new Date(Date.now() - MS_PER_DAY * args.daysBeforeAncient)
-    ) {
-      if (typeof args.minimumUpvotesToExempt !== 'undefined') {
-        if (
-          await hasEnoughUpvotes(
-            client,
-            issue.number,
-            args.minimumUpvotesToExempt
-          )
-        ) {
-          log.debug('issue is ancient but has enough upvotes to exempt');
+    } else {
+      const dateToCompare = (args.useCreatedDateForAncient ? Date.parse(issue.created_at) : Date.parse(issue.updated_at));
+      log.debug(`using issue ${args.useCreatedDateForAncient ? "created date" : "last updated"} to determine if the issue is ancient.`);
+      if (
+        dateToCompare < new Date(Date.now() - MS_PER_DAY * args.daysBeforeAncient)
+      ) {
+        if (typeof args.minimumUpvotesToExempt !== 'undefined') {
+          if (
+            await hasEnoughUpvotes(
+              client,
+              issue.number,
+              args.minimumUpvotesToExempt
+            )
+          ) {
+            log.debug('issue is ancient but has enough upvotes to exempt');
+          } else {
+            log.debug('issue is ancient and not enough upvotes; marking stale');
+            if (ancientMessage) {
+              if (args.dryrun) {
+                log.info(
+                  `dry run: would mark #${issue.number} as ${staleLabel} due to ${args.useCreatedDateForAncient ? "created date" : "last updated"} age`
+                );
+              } else {
+                await markStale(client, issue, ancientMessage, staleLabel);
+              }
+            } else {
+              log.debug(`ancient message is null/empty, doing nothing`);
+            }
+          }
         } else {
           log.debug('issue is ancient and not enough upvotes; marking stale');
-          if (args.dryrun) {
-            log.info(
-              `dry run: would mark #${issue.number} as ${staleLabel} due to last updated age`
-            );
+          if (ancientMessage) {
+            if (args.dryrun) {
+              log.info(
+                `dry run: would mark #${issue.number} as ${staleLabel} due to ${args.useCreatedDateForAncient ? "created date" : "last updated"} age`
+              );
+            } else {
+              await markStale(client, issue, ancientMessage, staleLabel);
+            }
           } else {
-            await markStale(client, issue, ancientMessage, staleLabel);
+            log.debug(`ancient message is null/empty, doing nothing`);
           }
-        }
-      } else {
-        log.debug('issue is ancient and not enough upvotes; marking stale');
-        if (args.dryrun) {
-          log.info(
-            `dry run: would mark #${issue.number} as ${staleLabel} due to last updated age`
-          );
-        } else {
-          await markStale(client, issue, ancientMessage, staleLabel);
         }
       }
     }

--- a/src/github.js
+++ b/src/github.js
@@ -133,6 +133,7 @@ module.exports.getIssues = async (client, args) => {
   }
 
   if (args.ancientIssueMessage && args.ancientIssueMessage !== '') {
+    log.debug(`using issue ${args.useCreatedDateForAncient ? "created date" : "last updated"} to determine for getting ancient issues.`);
     options = client.issues.listForRepo.endpoint.merge({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -144,7 +145,7 @@ module.exports.getIssues = async (client, args) => {
     const ancientResults = await client.paginate(options);
     ancientIssues = ancientResults.filter(
       (issue) =>
-        new Date(issue.updated_at) <
+        (args.useCreatedDateForAncient ? new Date(issue.created_at) : new Date(issue.updated_at)) <
         new Date(Date.now() - MS_PER_DAY * args.daysBeforeAncient)
     );
     log.debug(`found ${ancientIssues.length} ancient issues`);

--- a/test/entrypoint.test.js
+++ b/test/entrypoint.test.js
@@ -48,6 +48,7 @@ describe('GitHub issue parser', () => {
       minimumUpvotesToExempt: parseInt(process.env.MINIMUM_UPVOTES_TO_EXEMPT),
       cfsLabel: process.env.CFS_LABEL,
       issueTypes: process.env.ISSUE_TYPES.split(","),
+      useCreatedDateForAncient: !!process.env.USE_CREATED_DATE_FOR_ANCIENT
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added environment variable/argument use-created-date-for-ancient which if set to true uses issue created date instead of modified date for determining an ancient issue.

___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
