### PR TITLE
Update mhart/alpine-node dockerfile to node14.17.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:14
+FROM mhart/alpine-node:14.17.3
 
 LABEL "repository"="https://github.com/aws-actions/stale-issue-cleanup"
 LABEL "version"="0.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:12
+FROM mhart/alpine-node:16
 
 LABEL "repository"="https://github.com/aws-actions/stale-issue-cleanup"
 LABEL "version"="0.1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:16
+FROM mhart/alpine-node:14
 
 LABEL "repository"="https://github.com/aws-actions/stale-issue-cleanup"
 LABEL "version"="0.1.0"


### PR DESCRIPTION
*Issue #, if available:*
```
error jest@29.4.0: The engine "node" is incompatible with this module. Expected version "^14.15.0 || ^16.10.0 || >=18.0.0". Got "12.22.3"
```
*Description of changes:*
This PR fixes the issue caused by jest `29.4.0` dependency update, which requires Node version "^14.15.0 || ^16.10.0 || >=18.0.0". Currently, Dockerfile is using Node version 12.22.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
