### PR TITLE
Updated Dockerfile to use node:18-alpine3.16 image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:12
+FROM node:18-alpine3.16
 
 LABEL "repository"="https://github.com/aws-actions/stale-issue-cleanup"
 LABEL "version"="0.1.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tested the change locally with the jest version `^29.4.0` dependency, which was reverted in commit https://github.com/aws-actions/stale-issue-cleanup/commit/f914f91e45e5ad011fade57b78eca9d929d6b930 (since it required Node version `"^14.15.0 || ^16.10.0 || >=18.0.0"`).
___
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
